### PR TITLE
Atualiza acoes da SEPLAG que identificam despesas da CET e CAMG

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: relatoriosOBZ
 Type: Package
 Title: What the Package Does (Title Case)
-Version: 0.1.2
+Version: 0.1.3
 Author: Who wrote it
 Maintainer: The package maintainer <yourself@somewhere.net>
 Description: More about what it does (maybe more than one line)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: relatoriosOBZ
 Type: Package
 Title: What the Package Does (Title Case)
-Version: 0.1.3
+Version: 0.1.2
 Author: Who wrote it
 Maintainer: The package maintainer <yourself@somewhere.net>
 Description: More about what it does (maybe more than one line)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,75 +1,54 @@
 remap_unidades <- function(data, uo = NULL, acao = NULL) {
   dt <- data.table::copy(data)
 
-  # 
   if(!is.null(uo)) {
-    data.table::setnames(dt, uo, "uo_cod")
+    data.table::setnames(dt, uo, "UO_COD")
   }
 
   if(!is.null(acao)) {
-    data.table::setnames(dt, acao, "acao_cod")
+    data.table::setnames(dt, acao, "ACAO_COD")
   }
 
-
-  # 2023 ----------------------------------------------------------------------- 
-
   dt[
-    uo_cod == 1511 & ano == 2023 & acao_cod %in% c(4019, 4021, 4020, 4017, 4018), uo_cod := 1551
+    UO_COD == 1511 & ACAO_COD %in% c(4019, 4021, 4020, 4017, 4018), UO_COD := 1551
   ]
   
   dt[
-    uo_cod == 1501 & ano == 2023 & acao_cod %in% c(4480, 4481, 4482), uo_cod := 1502
+    UO_COD == 1501 & ACAO_COD %in% c(4480, 4481, 4482), UO_COD := 1502
   ]
 
 
-  # em 2023 houve transposição das ações da pcmg para a seplag
+  # em 2023 houve transposição das ações da PCMG para a SEPLAG
   dt[
-    (uo_cod == 1511 | 1501) & ano == 2023 & acao_cod %in% c(4100, 4105, 4124, 4134, 4135), uo_cod := 1551
-  ]
-
-  dt[
-    uo_cod == 1221 & ano == 2023 & acao_cod == 4408, uo_cod := 1721
+    (UO_COD == 1511 | 1501) & ACAO_COD %in% c(4100, 4105, 4124, 4134, 4135), UO_COD := 1551
   ]
 
   dt[
-    uo_cod == 1491 & ano == 2023 & acao_cod == 2015, uo_cod := 1721
+    UO_COD == 1221 & ACAO_COD == 4408, UO_COD := 1721
   ]
 
   dt[
-    uo_cod == 1501 & ano == 2023 & acao_cod == 4140, uo_cod := 1721
+    UO_COD == 1491 & ACAO_COD == 2015, UO_COD := 1721
   ]
 
   dt[
-    uo_cod == 1631 & ano == 2023 & acao_cod %in% c(2058, 2059), uo_cod := 1711
+    UO_COD == 1501 & ACAO_COD == 4140, UO_COD := 1721
   ]
 
   dt[
-    uo_cod == 1631 & ano == 2023 & acao_cod == 2060, uo_cod := 1491
+    UO_COD == 1631 & ACAO_COD %in% c(2058, 2059), UO_COD := 1711
   ]
 
-
-  
-  # 2024 -----------------------------------------------------------------------
-  
-  # transposição das acoes da seplag para uo's ficticias camg (1502) e cet (1503)
-
-  # seplag - camg
   dt[
-    uo_cod == 1501 & ano == 2024 & acao_cod %in% c(1085, 4465, 4466, 4467), uo_cod := 1502
+    UO_COD == 1631 & ACAO_COD == 2060, UO_COD := 1491
   ]
-
-  # seplag - cet
-  dt[
-    uo_cod == 1501 & ano == 2024 & acao_cod %in% c(4491, 4492, 4494, 4495, 4496), uo_cod := 1503
-  ]
-
 
   if(!is.null(uo)) {
-    data.table::setnames(dt, "uo_cod", uo)
+    data.table::setnames(dt, "UO_COD", uo)
   }
 
   if(!is.null(acao)) {
-    data.table::setnames(dt, "acao_cod", acao)
+    data.table::setnames(dt, "ACAO_COD", acao)
   }
 
   return(dt[])

--- a/R/utils.R
+++ b/R/utils.R
@@ -12,11 +12,18 @@ remap_unidades <- function(data, uo = NULL, acao = NULL) {
   dt[
     UO_COD == 1511 & ACAO_COD %in% c(4019, 4021, 4020, 4017, 4018), UO_COD := 1551
   ]
-  
+
+  dt[
+    ANO == 2024 & UO_COD == 1501 & ACAO_COD %in% c(4491, 4492, 4494, 4495, 4496), UO_COD := 1551
+  ]
+
   dt[
     UO_COD == 1501 & ACAO_COD %in% c(4480, 4481, 4482), UO_COD := 1502
   ]
 
+  dt[
+    ANO == 2024 & UO_COD == 1501 & ACAO_COD %in% c(1085, 4465, 4466, 4467), UO_COD := 1502
+  ]
 
   # em 2023 houve transposição das ações da PCMG para a SEPLAG
   dt[


### PR DESCRIPTION
Closes #1

- Revert "atualiza funcao remap_unidades para incluir criterios de transposicao das acoes da SEPLAG para UOs ficticias CAMG e CET"
- adiciona criterios transposicao seplag para cet e camg para 2024
